### PR TITLE
Prod ing user entry

### DIFF
--- a/topical/serializers.py
+++ b/topical/serializers.py
@@ -51,19 +51,13 @@ class ProductSerializer(serializers.HyperlinkedModelSerializer):
 
 	def create(self, validated_data):
 		ingredients_data = validated_data.pop('ingredients', [])
-		#print("popped")
-		#print(ingredients_data)
 		product = Product.objects.create(**validated_data)
 		for ingredient_data in ingredients_data:
 			if len(IngredientName.objects.filter(name__iexact = ingredient_data.get('name'))):
 				print("duplicate")
 				continue
 			ingredient_name = ingredient_data.get('name')
-			#print("ingredient name")
-			#print(ingredient_name)
 			new_ingredient = Ingredient.objects.create(name=ingredient_name)
-			#print("ingredient object")
-			#print(new_ingredient)
 			product.ingredients.add(new_ingredient)
 		return product
 

--- a/topical/serializers.py
+++ b/topical/serializers.py
@@ -47,6 +47,26 @@ class IngredientNameSerializer(serializers.HyperlinkedModelSerializer):
 		fields = ['name', 'ingredient']
 
 class ProductSerializer(serializers.HyperlinkedModelSerializer):
+	ingredients = IngredientSerializer(many=True, required=False)
+
+	def create(self, validated_data):
+		ingredients_data = validated_data.pop('ingredients', [])
+		#print("popped")
+		#print(ingredients_data)
+		product = Product.objects.create(**validated_data)
+		for ingredient_data in ingredients_data:
+			if len(IngredientName.objects.filter(name__iexact = ingredient_data.get('name'))):
+				print("duplicate")
+				continue
+			ingredient_name = ingredient_data.get('name')
+			#print("ingredient name")
+			#print(ingredient_name)
+			new_ingredient = Ingredient.objects.create(name=ingredient_name)
+			#print("ingredient object")
+			#print(new_ingredient)
+			product.ingredients.add(new_ingredient)
+		return product
+
 	class Meta:
 		model = Product
-		fields = ['name', 'upc', 'image_url', 'description'] 
+		fields = ['name', 'upc', 'image_url', 'description', 'ingredients'] 


### PR DESCRIPTION
Product ingredient user entry.  Leaving this one well-enough alone for now; we can revisit if we have time and see about taking this out of the serializer and making it a dedicated endpoint.  New ingredients are identified and registered, the new product is added to the db, and the ingredients are then associated with that product.  The data coming in should follow this structure:
{
    "name": "Panama Jack Pure Aloe Vera Gel Fresh Scent",
    "upc": "045336031083",
    "image_url": null,
    "description": "12 oz",
    "ingredients": [
			{"name": "Aloe Vera Gel"}, {"name": "Triethanolamine"}, {"name": "Carbomer"}, {"name": "Diazolidinyl Urea"}, {"name": "Dmdm Hydantoin"}, {"name": "Octoxynol 9"}, {"name": "Fd&c Blue No. 1"}, {"name": "Fd&c Yellow No. 5"}, {"name": "Fragrance"}]
  }